### PR TITLE
Adds test of Auth0 registration event (ss) processing to facilitate test-driven development of that process 

### DIFF
--- a/src/user_registration.py
+++ b/src/user_registration.py
@@ -1,0 +1,61 @@
+#
+#   Thiscovery API - THIS Institute’s citizen science platform
+#   Copyright (C) 2019 THIS Institute
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   A copy of the GNU Affero General Public License is available in the
+#   docs folder of this project.  It is also available www.gnu.org/licenses/
+#
+import json
+from http import HTTPStatus
+import thiscovery_lib.utilities as utils
+import thiscovery_lib.notification_send as notif_send
+from thiscovery_lib.core_api_utilities import CoreApiClient
+
+import common.constants as const
+
+
+@utils.lambda_wrapper
+def record_user_registration_event(event, context):
+    # todo: write the code for this lambda handler; the example below is from user_login.py
+    pass
+    # namespace = utils.get_aws_namespace()
+    # logger = event["logger"]
+    # logger.info("API call", extra={"namespace": namespace, "event": event})
+    #
+    # # # Note that Auth0 event log sources are either prod or staging. If this code is being invoked in other environments then
+    # # # it is because events are being forwarded for dev/test purposes.  In this scenario the user referred to in the event will
+    # # # not exist in this environment's RDS database or HubSpot database.  So ignore.
+    # # if namespace in ['/prod/', '/staging/']:
+    #
+    # # event will contain an Auth0 event of type 's''
+    # event_id = event[
+    #     "id"
+    # ]  # note that event id will be used as correlation id for subsequent processing
+    # detail_data = event["detail"]["data"]
+    # event_type = detail_data["type"]
+    # login_datetime = detail_data["date"].replace("T", " ").replace("Z", "")
+    # user_email = detail_data["user_name"]
+    # core_api_client = CoreApiClient(correlation_id=event_id)
+    # user = core_api_client.get_user_by_email(email=user_email)
+    # for x in ["has_demo_project", "has_live_project", "title"]:
+    #     del user[x]
+    # login_info = {
+    #     **user,
+    #     "login_datetime": login_datetime,
+    # }
+    # notif_send.notify_user_login(
+    #     login_info,
+    #     event_id,
+    #     stack_name=const.STACK_NAME,
+    # )
+    # return {"statusCode": HTTPStatus.OK, "body": json.dumps("")}

--- a/template.yaml
+++ b/template.yaml
@@ -1,4 +1,6 @@
 Transform: AWS::Serverless-2016-10-31
+
+
 Resources:
   CustomEmail:
     Type: AWS::Serverless::Function
@@ -35,6 +37,85 @@ Resources:
             StackeryName: CustomEmail
       Layers:
         - arn:aws:lambda:eu-west-1:066549572091:layer:epsagon-python-layer:325
+
+  RecordUserLogin:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${AWS::StackName}-RecordUserLogin
+      Description: !Sub
+        - Stack ${StackTagName} Environment ${EnvironmentTagName} Function ${ResourceName}
+        - ResourceName: RecordUserLogin
+      CodeUri: src
+      Handler: user_login.record_user_login_event
+      Runtime: python3.8
+      MemorySize: !Ref EnvConfiglambdamemorysizeAsString
+      Timeout: !Ref EnvConfiglambdatimeoutAsString
+      Tracing: Active
+      Policies:
+        - AWSXrayWriteOnlyAccess
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${EnvironmentTagName}/*
+        - DynamoDBCrudPolicy:
+            TableName: !Ref notifications
+      Environment:
+        Variables:
+          SECRETS_NAMESPACE: !Sub /${EnvironmentTagName}/
+          TABLE_NAME: !Ref notifications
+          TABLE_ARN: !GetAtt notifications.Arn
+      Events:
+        EventRule:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              detail-type:
+                - Auth0 log
+              detail:
+                data:
+                  type:
+                    - s
+            EventBusName: !Ref EnvConfigeventbridgeauth0eventbusAsString
+          Metadata:
+            StackeryName: RecordUserLogin
+
+  RecordUserRegistration:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${AWS::StackName}-RecordUserRegistration
+      Description: !Sub
+        - Stack ${StackTagName} Environment ${EnvironmentTagName} Function ${ResourceName}
+        - ResourceName: RecordUserRegistration
+      CodeUri: src
+      Handler: user_registration.record_user_registration
+      Runtime: python3.8
+      MemorySize: !Ref EnvConfiglambdamemorysizeAsString
+      Timeout: !Ref EnvConfiglambdatimeoutAsString
+      Tracing: Active
+      Policies:
+        - AWSXrayWriteOnlyAccess
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${EnvironmentTagName}/*
+        - DynamoDBCrudPolicy:
+            TableName: !Ref notifications
+      Environment:
+        Variables:
+          SECRETS_NAMESPACE: !Sub /${EnvironmentTagName}/
+          TABLE_NAME: !Ref notifications
+          TABLE_ARN: !GetAtt notifications.Arn
+      Events:
+        EventRule:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              detail-type:
+                - Auth0 log
+              detail:
+                data:
+                  type:
+                    - ss
+            EventBusName: !Ref EnvConfigeventbridgeauth0eventbusAsString
+          Metadata:
+            StackeryName: RecordUserRegistration
+
   notifications:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -63,6 +144,7 @@ Resources:
             ProjectionType: ALL
     Metadata:
       StackeryName: Notifications
+
   tokens:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/tests/unit_tests/test_user_registration.py
+++ b/tests/unit_tests/test_user_registration.py
@@ -1,0 +1,100 @@
+#
+#   Thiscovery API - THIS Institute’s citizen science platform
+#   Copyright (C) 2019 THIS Institute
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   A copy of the GNU Affero General Public License is available in the
+#   docs folder of this project.  It is also available www.gnu.org/licenses/
+#
+import local.dev_config
+import local.secrets
+import thiscovery_lib.notifications as notif
+import thiscovery_lib.utilities as utils
+from thiscovery_dev_tools import testing_tools as test_tools
+from thiscovery_dev_tools.test_data.auth0_events import SUCCESSFUL_REGISTRATION
+from thiscovery_lib.lambda_utilities import Lambda
+
+import src.common.constants as const
+import src.user_registration as ur
+
+from tests.unit_tests.test_user_login import TEST_USER_01_JSON
+
+
+class TestUserRegistration(test_tools.BaseTestCase):
+    """
+    This test checks that lambda function RecordUserRegistration can receive
+    a ss Auth0 event as input and save a registration notification to the queue
+    of notifications to be processed in the Dynamodb notifications table. If we
+    keep the notification structure the same as it is at present in thiscovery-core,
+    it will look like this:
+    {
+        "id": "89ed5ae0-1f37-489f-ba58-16c5ac7bad60",
+        "processing_status": "new",
+        "label": "altha@email.co.uk",
+        "created": "2022-02-25 10:48:31.407821+00:00",
+        "details": {
+            "created": "2022-02-25 10:48:31.164191+00:00",
+            "avatar_string": "AA",
+            "last_name": "Alcorn",
+            "title": null,
+            "country_code": "GB",
+            "crm_id": null,
+            "country_name": "United Kingdom - England",
+            "modified": "2022-02-25 10:48:31.164191+00:00",
+            "id": "89ed5ae0-1f37-489f-ba58-16c5ac7bad60",
+            "auth0_id": "6218b3ff6a20e40071c72e51",
+            "first_name": "Altha",
+            "email": "Altha",
+            "status": "new"
+        },
+        "modified": "2022-02-25 10:53:17.312532+00:00",
+        "type": "user-registration"
+    }
+
+    Note that:
+        - this test only checks the notification was added to the processing queue.
+            The correct processing of notifications of this type needs to be tested
+            separately
+        - when this notification is processed, we will receive a crm_id back from
+            HubSpot for this user. That needs to be passed back to thiscovery-core
+            so that it can be stored in RDS. I suggest doing so via an EventBridge
+            event
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        notif.delete_all_notifications(stack_name=const.STACK_NAME)
+
+    def test_record_user_registration_ok(self):
+        user_json = TEST_USER_01_JSON
+        if utils.running_on_aws():
+            lambda_client = Lambda(stack_name=const.STACK_NAME)
+            lambda_client.invoke(
+                function_name="RecordUserRegistration",
+                invocation_type="Event",
+                payload=SUCCESSFUL_REGISTRATION,
+            )
+        else:
+            ur.record_user_registration_event(SUCCESSFUL_REGISTRATION, None)
+        notifications = notif.get_notifications(stack_name=const.STACK_NAME)
+        self.assertEqual(1, len(notifications))
+
+        notification = notifications[0]
+        self.assertEqual("user-registration", notification["type"])
+        self.assertEqual(user_json["email"], notification["label"])
+        self.assertEqual(
+            notif.NotificationStatus.NEW.value,
+            notification[notif.NotificationAttributes.STATUS.value],
+        )
+        self.assertEqual(user_json["email"], notification["details"]["email"])
+        self.assertEqual(user_json["id"], notification["details"]["id"])
+        self.now_datetime_test_and_remove(notification, "created", tolerance=10)


### PR DESCRIPTION
Sophie, if you can make the test in test_user_registration.py pass, you will have completed the first step in the move of registration processing from core to crm. See the test docstring for more info and notes. Let me know if you have any questions.